### PR TITLE
fix:버튼 사이즈 확장성 수정 & borderRadius 프랍추가

### DIFF
--- a/src/components/atoms/Button.jsx
+++ b/src/components/atoms/Button.jsx
@@ -9,28 +9,29 @@ import styled, { css } from 'styled-components';
 
 // eslint-disable-next-line react/prop-types
 // eslint-disable-next-line no-unused-vars
-function Button({ width, height, color, constrast, text }) {
+function Button({ width, height, color, constrast, text, borderRadius }) {
   return (
     <BtnContainer
       width={width}
       height={height}
       color={color}
-      constrast={constrast}>
+      constrast={constrast}
+      borderRadius={borderRadius}>
       {text}
     </BtnContainer>
   );
 }
 
 const BtnContainer = styled.button`
-  ${({ color, width, height, constrast }) => css`
+  ${({ color, width, height, constrast, borderRadius }) => css`
     display: inline-flex;
     justify-content: center;
     align-items: center;
     padding: 0.2em 1em 0.4em 1em;
-    border: solid ${color} 1px;
+    border: solid ${color} ${borderRadius}px;
     border-radius: 4px;
-    width: ${width}px;
-    height: ${height}px;
+    width: ${width};
+    height: ${height};
     ${constrast
       ? css`
           background-color: ${color};
@@ -43,19 +44,21 @@ const BtnContainer = styled.button`
 `;
 
 Button.propTypes = {
-  width: PropTypes.number,
-  height: PropTypes.number,
+  width: PropTypes.string,
+  height: PropTypes.string,
   color: PropTypes.string,
   constrast: PropTypes.bool,
   text: PropTypes.string,
+  borderRadius: PropTypes.number,
 };
 
 Button.defaultProps = {
-  width: 100,
-  height: 30,
+  width: '100%',
+  height: '30px',
   color: 'black',
   constrast: false,
   text: '버튼',
+  borderRadius: 1,
 };
 
 export default Button;


### PR DESCRIPTION
`<Button width="100%" height="40px" color="red" constrast={false or true} borderRadius={1} text="button" />`

- width, height: 기존 px 고정에서 원하는 단위로 변경 가능하도록 수정했습니다.
- color: 테두리와 글씨 색을 결정합니다
- constrast: 기본값 false 상태로 true로 변경하게 되면 배경색과 글자색이 반전됩니다
- borderRadius: px 단위로 모서리 값 고정 가능합니다.
- text: 버튼 안에 텍스트 값입니다.