### PR TITLE
Feat: Input에 state 저장 및 변경 로직 추가

### DIFF
--- a/src/components/atoms/Input.jsx
+++ b/src/components/atoms/Input.jsx
@@ -2,14 +2,16 @@ import React from 'react';
 import PropTypes from 'prop-types';
 import styled from 'styled-components';
 
-function Input({ placeholder }) {
-  return <StInput type="text" placeholder={placeholder} />;
+function Input({ placeholder, inputData, setInputData }) {
+  return <StInput type="text" placeholder={placeholder} value={inputData} onChange={(e) => setInputData(e.target.value)} />;
 }
 
 export default Input;
 
 Input.propTypes = {
   placeholder: PropTypes.string.isRequired,
+  inputData: PropTypes.string.isRequired,
+  setInputData: PropTypes.func.isRequired,
 };
 
 const StInput = styled.input`


### PR DESCRIPTION
- [x] inputData : 상위 컴포넌트에서 state를 props로 전달
- [x] setInputData : 상위 컴포넌트에서 set함수를 props로 전달 

### 생각해야할 것
- onChange에 set함수를 지정했기 때문에 입력값마다 Input과 상위 컴포넌트가 렌더링.
  불필요한 렌더링이 많이 일어날 수 있어 후에 개선필요할 것 같습니다.